### PR TITLE
Update ruby upgrades token

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -26,4 +26,4 @@ jobs:
           shopt -s globstar
           updatecli apply --config updatecli/updatecli.d --values updatecli/values.yaml
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.UPGRADE_RUBY_TOKEN }}"


### PR DESCRIPTION
It is necessary to update ruby upgrades token to avoid github limitation in workflows